### PR TITLE
投稿前に確認ダイアログを表示

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,11 @@
 
         $(function () {
             $('.post').on('click', function (event) {
+                const isAgreed = window.confirm('投稿しますか？')
+                if (!isAgreed) {
+                    console.log('キャンセルしました')
+                    return
+                }
                 let url = 'https://slack.com/api/chat.postMessage';
                 let ele_id = $(this).attr('id');
                 let data = {


### PR DESCRIPTION
# Before
ボタンを押すとすぐに投稿されるので、間違った場合、後で「間違いました」のボタンを押して、投稿する必要があった

# After
投稿ボタン押したら、確認ダイアログを表示して、OKだったら投稿するようになった